### PR TITLE
fix: the furnace now continue to smelt after the first item

### DIFF
--- a/data/nbt_smelting/functions/v1.7/furnace/start_smelt.mcfunction
+++ b/data/nbt_smelting/functions/v1.7/furnace/start_smelt.mcfunction
@@ -9,9 +9,6 @@ execute if score #output_count nbt_smelting.data >= #output_stacksize nbt_smelti
 scoreboard players set @s nbt_smelting.data 0
 
 # Check if current input matches output
-scoreboard players set #enable nbt_smelting.data 0
-execute if score #output_count nbt_smelting.data matches 0 run scoreboard players set #enable nbt_smelting.data 1
-
 execute if score #output_count nbt_smelting.data matches 1.. run data modify storage nbt_smelting:io item set from block ~ ~ ~ Items[{Slot:0b}]
 execute if score #output_count nbt_smelting.data matches 1.. run data remove storage nbt_smelting:io item.Slot
 execute if score #output_count nbt_smelting.data matches 1.. run data remove storage nbt_smelting:io item.count
@@ -19,5 +16,5 @@ execute if score #output_count nbt_smelting.data matches 1.. store success score
 execute if score #output_count nbt_smelting.data matches 1.. if score #failed nbt_smelting.data matches 1 run return fail
 
 # Start Smelting
-execute if score #enable nbt_smelting.data matches 1 if items block ~ ~ ~ container.1 * if block ~ ~ ~ #nbt_smelting:furnaces{BurnTime:0s} run function nbt_smelting:v1.7/furnace/fuel
-execute if score #enable nbt_smelting.data matches 1 unless block ~ ~ ~ #nbt_smelting:furnaces{BurnTime:0s} run tag @s add nbt_smelting.furnace.active
+execute if items block ~ ~ ~ container.1 * if block ~ ~ ~ #nbt_smelting:furnaces{BurnTime:0s} run function nbt_smelting:v1.7/furnace/fuel
+execute unless block ~ ~ ~ #nbt_smelting:furnaces{BurnTime:0s} run tag @s add nbt_smelting.furnace.active


### PR DESCRIPTION
In the process of making my datapack, I noticed that a furnace with a custom recipe does not continue to smelt after the first item is cooked.

This is due to [this file (v1.6)](https://github.com/ICY105/NBTSmelting/blob/v1.6/data/nbt_smelting/functions/v1.5/furnace/start_smelt.mcfunction) that wasn't properly updated from 1.20.4 to 1.20.5.

## In v1.6 (MC 1.20.4)
The `#enable nbt_smelting.data` score was:
- set to zero
- if output_count == 0
    - set to 1
- if output_count >= 1
    - NBT check with stored item & set to 1
    - check the stack_size & set to 0 if reached

Then if `#enable nbt_smelting.data` was 1, the lib would consume the fuel & add the tag `nbt_smelting.furnace.active`, triggering the smelting behaviour.

## In v1.7 (MC 1.20.5)
The `#enable nbt_smelting.data` score is now:
- set to zero
- if output_count == 0
    - set to 1

And that's it, the NBT check & stack_size now use the `return fail` command. 
Now it never smelts anything if there is already an item in the output.

## My PR
Just remove this score behaviour because, in case of a failing the code that smelts the item is no longer executed.
